### PR TITLE
fix(404 page): preserve line breaks in ASCII art

### DIFF
--- a/404.html
+++ b/404.html
@@ -64,10 +64,7 @@
 
     pre, p, em, br, a {
         z-index: 4;
-
         opacity: 0.9;
-        white-space: unset;
-
     }
 
     pre {


### PR DESCRIPTION
This removes the property which unset line breaks to be respected; so that line breaks are enforced now. Without this property, the ASCII art is scrambled.

Although, I had my doubts if this was intentional or not, considering it spells out "SYSTEM FAILURE". I wasn't sure if that was intended to be in reference to a failure in the ASCII, the error document or both. If any of those are the case, feel free to close this.